### PR TITLE
Updated requirements notes in running-amazon-ec2-workloads-at-scale

### DIFF
--- a/content/running-amazon-ec2-workloads-at-scale/requirements_notes.md
+++ b/content/running-amazon-ec2-workloads-at-scale/requirements_notes.md
@@ -13,7 +13,7 @@ weight = 10
 
 {{% notice note %}}
 If you are attending an event, please run in the region suggested by the facilitators of the workshop.\
-Currently, the following AWS regions support Cloud9 and the EC2 instance types that are configured for this workshop: us-east-1 (N. Virginia), us-east-2 (Ohio), us-west-2 (Oregon), eu-west-1 (Dublin), ap-southeast-1 (Singapore)
+Currently, the following AWS regions support Cloud9 and the EC2 instance types that are configured for this workshop: us-east-1 (N. Virginia), us-east-2 (Ohio), us-west-2 (Oregon), eu-west-1 (Dublin), ap-southeast-1 (Singapore), ap-northeast-1 (Tokyo)
 {{% /notice %}}
 
 5\. During this workshop, you will install software (and dependencies) on the Amazon EC2 instances launched in your account. The software packages and/or sources you will install will be from the [Amazon Linux 2](https://aws.amazon.com/amazon-linux-2/) distribution as well as from third party repositories and sites. Please review and decide your comfort with installing these before continuing.


### PR DESCRIPTION
*Description of changes:*

Have already added Cloud9 region at Tokyo, so fixed the requirement notes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.