### PR TITLE
ran-k8s-ee-instructions

### DIFF
--- a/content/using_ec2_spot_instances_with_eks/cleanup.md
+++ b/content/using_ec2_spot_instances_with_eks/cleanup.md
@@ -4,6 +4,11 @@ date: 2018-08-07T08:30:11-07:00
 weight: 100
 ---
 
+{{% notice note %}}
+If you're running in an account that was created for you as part of an AWS event, there's no need to go through the cleanup stage - the account will be closed automatically.\
+If you're running in your own account, make sure you run through these steps to make sure you don't encounter unwanted costs.
+{{% /notice %}}
+
 {{% notice tip %}}
 Before you clean up the resources and complete the workshop, you may want to review the complete some of the optional exercises in previous section of this workshop; or alternatively, take a look at the content and modules available at **[eksworkshop.com](https://eksworkshop.com/)**. Perhaps there are modules that you would like to try on EC2 Spot instances!
 {{% /notice %}}

--- a/content/using_ec2_spot_instances_with_eks/jenkins/jenkins_cleanup.md
+++ b/content/using_ec2_spot_instances_with_eks/jenkins/jenkins_cleanup.md
@@ -4,6 +4,10 @@ date: 2018-08-07T08:30:11-07:00
 weight: 90
 ---
 
+{{% notice note %}}
+If you're running in an account that was created for you as part of an AWS event, there's no need to go through the cleanup stage - the account will be closed automatically.\
+If you're running in your own account, make sure you run through these steps to make sure you don't encounter unwanted costs.
+{{% /notice %}}
 
 ### Removing the Jenkins server
 ```

--- a/content/using_ec2_spot_instances_with_eks/prerequisites/aws_event.md
+++ b/content/using_ec2_spot_instances_with_eks/prerequisites/aws_event.md
@@ -12,10 +12,15 @@ Kubecon, Immersion Day, or any other event hosted by an AWS employee). If you
 are running the workshop on your own, go to: [Start the workshop on your own]({{< relref "self_paced.md" >}}).
 {{% /notice %}}
 
-### Login to AWS Workshop Portal
+### Login to the AWS Workshop Portal
 
-This workshop creates an AWS acccount and a Cloud9 environment. You will need the **Participant Hash** provided upon entry, and your email address to track your unique session.
+If you are at an AWS event, an AWS acccount was created for you to use throughout the workshop. You will need the **Participant Hash** provided to you by the event's organizers.
 
-Connect to the portal by clicking the button or browsing to [https://dashboard.eventengine.run/](https://dashboard.eventengine.run/).
+1. Connect to the portal by browsing to [https://dashboard.eventengine.run/](https://dashboard.eventengine.run/).
+2. Enter the Hash in the text box, and click **Proceed** 
+3. In the User Dashboard screen, click **AWS Console** 
+4. In the popup page, click **Open Console** 
+
+You are now logged in to the AWS console in an account that was created for you, and will be available only throughout the workshop run time.
 
 Once you have completed the step above, **you can head straight to [Create a Workspace]({{< relref "workspace.md" >}})**


### PR DESCRIPTION
Adding some more prescriptive instructions on how to login to the EE dashboard and get to the console in the team's account.
