### PR TITLE
Rename env var in docs

### DIFF
--- a/content/running-amazon-ec2-workloads-at-scale/deploy_app_codedeploy.md
+++ b/content/running-amazon-ec2-workloads-at-scale/deploy_app_codedeploy.md
@@ -57,7 +57,7 @@ The CodeDeploy console will not default to your current region. Please make sure
 {{% /notice %}}
 
 
-1. Next, push the application to the CodeDeploy S3 bucket (which you initially loaded on the $code_deploy_bucket environment variable):
+1. Next, push the application to the CodeDeploy S3 bucket (which you initially loaded on the $codeDeployBucket environment variable):
 
 	```
 	aws deploy push --application-name koelApp --s3-location s3://$codeDeployBucket/koelApp.zip --no-ignore-hidden-files


### PR DESCRIPTION
*Description of changes:*
- Change env var to reflect the correct name, *$code_deploy_bucket* to *$codeDeployBucket* 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Luis Valdes <valdesis@amazon.com>