### PR TITLE
Minor re-vamp of Montecarlo workshop

### DIFF
--- a/content/monte-carlo-on-ec2-spot-fleet/lab3.md
+++ b/content/monte-carlo-on-ec2-spot-fleet/lab3.md
@@ -151,8 +151,11 @@ the two subnets available
 
 1. Check the *Fleet request settings* and check the fleet that has been selected. Notice how each entry has
 a different Spot price. Feel free to untick the **Apply Recommendations** and change the components in the fleet using: 
-c4.large, c5.large, m4.large, m5.large, t2.large, t3.large. Leave "Diversified" as the allocation strategy.
+c4.large, c5.large, m4.large, m5.large, t2.large, t3.large. Leave "Capacity Optimized" as the allocation strategy. 
 ![Instance Fleet Selection](/images/monte-carlo-on-ec2-spot-fleet/spot_fleet_flexible_instances_2.png)
+{{% notice info %}}
+You can read about **[Capacity Optimized](https://aws.amazon.com/about-aws/whats-new/2019/08/new-capacity-optimized-allocation-strategy-for-provisioning-amazon-ec2-spot-instances/)** and find out what are the last 30 days average for the frequency of interruptions on the selected instance types using **[Spot Instance Advisor](https://aws.amazon.com/ec2/spot/instance-advisor/)**
+{{% /notice %}}
 
 1. Click **Launch**.
 

--- a/content/monte-carlo-on-ec2-spot-fleet/lab4.md
+++ b/content/monte-carlo-on-ec2-spot-fleet/lab4.md
@@ -33,6 +33,7 @@ Please make sure you are using the Cloud9 environment created by the workshop Cl
 1. On the terminal run the following commands. This will download the repository of code we will
 use to build our image.
 ```
+sudo yum install -y jq
 git clone https://github.com/awslabs/ec2-spot-workshops.git
 cd ec2-spot-workshops/workshops/monte-carlo-on-ec2-spot-fleet
 ```
@@ -45,7 +46,7 @@ $(aws ecr get-login --region $REGION --no-include-email)
 
 1. Create a repository named **monte-carlo-workshop**.
 ```
-MONTE_CARLO_REGISTRY=$(aws ecr create-repository --repository-name monte-carlo-workshop | grep "repositoryUri" | awk '{split($0,a,":"); print a[2]}' | sed 's/"//g')
+MONTE_CARLO_REGISTRY=$(aws ecr create-repository --repository-name monte-carlo-workshop | jq --raw-output '.["repository"].repositoryUri')
 MONTE_CARLO_IMAGE=${MONTE_CARLO_REGISTRY}:latest
 echo "Monte carlo repository created at :$MONTE_CARLO_REGISTRY"
 echo "Monte carlo image name : $MONTE_CARLO_IMAGE"

--- a/static/config/monte-carlo-on-ec2-spot-fleet/monte-carlo-workshop.yaml
+++ b/static/config/monte-carlo-on-ec2-spot-fleet/monte-carlo-workshop.yaml
@@ -11,19 +11,19 @@ Mappings:
       CIDR: 10.0.0.0/16
   DeepLearningAmi:
     ap-northeast-1:
-      AMI: ami-0c1c7f04b4a0792d5
+      AMI: ami-0f7912d4a98edaa3d
     ap-northeast-2:  
-      AMI: ami-03293a3b93252b842
+      AMI: ami-088d1075e1f3e9005
     ap-southeast-2:
-      AMI: ami-0f6777438177dd7ec
+      AMI: ami-0c69f8de8ac863285
     eu-west-1:
-      AMI: ami-0c971caf926cf2589
+      AMI: ami-0c25aaf5533c8d846
     us-east-1:
-      AMI: ami-0c509141570009bb5
+      AMI: ami-08e68326c36bf3710
     us-east-2:
-      AMI: ami-072ab8ae3a4ed1d23
+      AMI: ami-0ca8d6784b6bf9ef6
     us-west-2:
-      AMI: ami-0faaeebada3dc9afb
+      AMI: ami-0389181a045a628d2
 Outputs:
   Jupyter:
     Description: URL to access Jupyter in Lab 2 (Use the password used in the stack JupyterPassword parameter)

--- a/static/config/monte-carlo-on-ec2-spot-fleet/monte-carlo-workshop.yaml
+++ b/static/config/monte-carlo-on-ec2-spot-fleet/monte-carlo-workshop.yaml
@@ -433,7 +433,7 @@ Resources:
     - publicSubnet1
     - spotFleetInstanceRole
     Properties:
-      Description: Running Amazon EC2 Workloads at Scale - Cloud9 environment
+      Description: MonteCarlo Workshop - Cloud9 environment
       InstanceType: t2.micro
       SubnetId:
         Ref: publicSubnet1


### PR DESCRIPTION
*Description of changes:*

Minor changes to:
 * Update AMI to use latest version of the Deep Learning v 26.0 AMI
 * Update References to use Capacity-optimized as an allocation strategy
 * Remove parsing of Json and use JQ instead to avoid potential issues
 * Rename the Cloud 9 environment.

As part of this PR I've also reviewed what's to come to this workshop on the next round, Just dumping my brain for the next time around:
 - Making the Jupyter Notebook for FSI optional and perhaps driving it from Sagemaker Notebooks. (The internals will still be available to cover FSI workshops, but there will be optional and will be hidden for general workshops where we would like to focus on ASG/Spot Fleet + SQS and AWS Batch). Goal is to focus on Focus on Spot related aspects
 - Lab 3 will focus on SQS + ASG and implement additional focus on automating the creation of Launch Templates and ASG's through command line and config (to expedite the workshop). The code will also shows how to use scale-in protection and demos will be not only on how to scale, but also on how to the scale-in protection actually prevents multi-process readers from being scaled in. 
 - Regarding the submission to SQS, A revamp of the FSI application will be created and will be linked to push not only to different abstracted pugins, for this workshop the configuration will focus on SQS and AWS Batch (app will be reused for other integrations). Results will be populated as well from using a chain of plugins (chain of responsability) and S3 will be added. To help submitting arbitrary batches of greater size, the tool will support the definition an load of a large portfolio + valuation strategies 
 - The batch workshop will be modified to use command line to set up compute environments, job queues and definitions and submission will be done directly from the application rather thanthrough SQS (as one should expect). Aspects such as allocation strategies and array job batch will be covered.
 - A visualisation section will be provided to update as results come in using quicksight . The idea is not that customers understand the portfolio generation part, but that can visually confirm that results are coming and the overall results are included. While we will keep this format for FSI, we may thing of other applications that make the visual aspect more interesting for other users. The FSI is still highly desirable for FSI engagements however.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
