### PR TITLE
FIx - removing the draft attribute from the cli page

### DIFF
--- a/content/using_ec2_spot_instances_with_eks/prerequisites/awscli.md
+++ b/content/using_ec2_spot_instances_with_eks/prerequisites/awscli.md
@@ -2,7 +2,6 @@
 title: "Update to the latest AWS CLI"
 chapter: false
 weight: 45
-draft: true
 comment: default install now includes aws-cli/1.15.83
 ---
 


### PR DESCRIPTION
*Issue #, if available:*

* AWS CLI v2 page was not showing up; It was marked as a draft. Removing the draft mark, we do need to display the instructions to upgrade the CLI


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
