### PR TITLE
decouple build and run of docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:alpine AS build
 
 RUN apk --no-cache --update add git gcc musl-dev g++
 RUN git clone -b 'v0.53' --single-branch --depth 1 https://github.com/gohugoio/hugo.git
@@ -7,5 +7,8 @@ RUN go install --tags extended
 WORKDIR /www
 RUN git clone https://github.com/matcornic/hugo-theme-learn/ themes/learn
 COPY . /www/
-ENTRYPOINT ["hugo", "server", "--bind", "0.0.0.0"]
-CMD [""]
+RUN /go/bin/hugo --destination /usr/share/nginx/html
+CMD ["hugo", "server", "--bind", "0.0.0.0"]
+
+FROM nginx:alpine
+COPY --from=build /usr/share/nginx/html /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,22 @@
+## First stage will build hugo
 FROM golang:alpine AS hugo
 
+# ARG can be changed at build-time; will be in the environment within `docker build` context, not afterwards
+ARG HUGO_VER="v0.53"
+
 RUN apk --no-cache --update add git gcc musl-dev g++
-RUN git clone -b 'v0.53' --single-branch --depth 1 https://github.com/gohugoio/hugo.git
+RUN git clone -b ${HUGO_VER} --single-branch --depth 1 https://github.com/gohugoio/hugo.git
 WORKDIR /go/hugo
 RUN go install --tags extended
 WORKDIR /www
 RUN git clone https://github.com/matcornic/hugo-theme-learn/ themes/learn
 CMD ["hugo", "server", "--bind", "0.0.0.0"]
 
+## Second stage will use the hugo container to build the website
 FROM hugo AS build
 COPY . /www/
 RUN /go/bin/hugo --destination /output
 
+## Final step serves the static website
 FROM nginx:alpine
 COPY --from=build /output /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS build
+FROM golang:alpine AS hugo
 
 RUN apk --no-cache --update add git gcc musl-dev g++
 RUN git clone -b 'v0.53' --single-branch --depth 1 https://github.com/gohugoio/hugo.git
@@ -6,9 +6,11 @@ WORKDIR /go/hugo
 RUN go install --tags extended
 WORKDIR /www
 RUN git clone https://github.com/matcornic/hugo-theme-learn/ themes/learn
-COPY . /www/
-RUN /go/bin/hugo --destination /usr/share/nginx/html
 CMD ["hugo", "server", "--bind", "0.0.0.0"]
 
+FROM hugo AS build
+COPY . /www/
+RUN /go/bin/hugo --destination /output
+
 FROM nginx:alpine
-COPY --from=build /usr/share/nginx/html /usr/share/nginx/html
+COPY --from=build /output /usr/share/nginx/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   hugo:
     build:
       context: .
-      target: hugo
+      target: build
     ports:
       - 1313:1313
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.7'
 services:
   hugo:
-    image: awslabs/ec2-spot-workshops:build
     build:
       context: .
+      target: hugo
     ports:
       - 1313:1313
     volumes:
@@ -11,4 +11,4 @@ services:
       - ./static:/www/static
       - ./layouts:/www/layouts
       - ./config.toml:/www/config.toml
-    command: ["--buildDrafts", "--buildFuture", "--watch"]
+    command: ["hugo", "server", "--bind", "0.0.0.0", "--buildDrafts", "--buildFuture", "--watch"]


### PR DESCRIPTION
*Issue*
When building the hugo website from certain networks (like VPN), it throttles the API calls to github and thus, the `hugo build` fails.
As reviewers do not really need to build the website when reviewing the artifact to deliver could just be a docker image that can be downloaded and instantiated.

*Description of changes:*
I changed the Dockerfile that it won't run the build step in the resulting image, but just use a small nginx image to host the static website. 
Additional benefit: The golang image grows to 1GB in size, while the nginx image will habe 120MB in the end.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
