### PR TITLE
Upgraded version of eksctl, managed nodegroups

### DIFF
--- a/content/using_ec2_spot_instances_with_eks/eksctl/launcheks.md
+++ b/content/using_ec2_spot_instances_with_eks/eksctl/launcheks.md
@@ -46,7 +46,7 @@ eksctl create cluster --version=1.15 --name=eksworkshop-eksctl --node-private-ne
 
 eksctl allows us to pass parameters to initialize the cluster. While initializing the cluster, eksctl does also allow us to create nodegroups.
 
-The managed nodegroup will have two m5.large nodes and it will bootstrap with the labels **lifecycle=OnDemand** and **intent=control-apps**. Note the managed nodegroup
+The managed nodegroup will have two m5.large nodes and it will bootstrap with the labels **lifecycle=OnDemand** and **intent=control-apps**. 
 
 {{% notice info %}}
 Launching EKS and all the dependencies will take approximately **15 minutes**

--- a/content/using_ec2_spot_instances_with_eks/eksctl/launcheks.md
+++ b/content/using_ec2_spot_instances_with_eks/eksctl/launcheks.md
@@ -41,12 +41,12 @@ The following command will create an eks cluster with the name `eksworkshop-eksc
 .It will also create a nodegroup with 2 on-demand instances.
 
 ```
-eksctl create cluster --version=1.15 --name=eksworkshop-eksctl --managed --nodes=2 --alb-ingress-access --region=${AWS_REGION} --node-labels="lifecycle=OnDemand,intent=control-apps" --asg-access
+eksctl create cluster --version=1.15 --name=eksworkshop-eksctl --node-private-networking  --managed --nodes=2 --alb-ingress-access --region=${AWS_REGION} --node-labels="lifecycle=OnDemand,intent=control-apps" --asg-access
 ```
 
 eksctl allows us to pass parameters to initialize the cluster. While initializing the cluster, eksctl does also allow us to create nodegroups.
 
-The managed nodegroup will have two m5.large nodes and it will bootstrap with the labels **lifecycle=OnDemand** and **intent=control-apps**.
+The managed nodegroup will have two m5.large nodes and it will bootstrap with the labels **lifecycle=OnDemand** and **intent=control-apps**. Note the managed nodegroup
 
 {{% notice info %}}
 Launching EKS and all the dependencies will take approximately **15 minutes**

--- a/content/using_ec2_spot_instances_with_eks/eksctl/prerequisites.md
+++ b/content/using_ec2_spot_instances_with_eks/eksctl/prerequisites.md
@@ -6,7 +6,7 @@ weight: 10
 
 For this module, we need to download the [eksctl](https://eksctl.io/) binary:
 ```
-export EKSCTL_VERSION=0.16.0
+export EKSCTL_VERSION=0.18.0
 curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_Linux_amd64.tar.gz" | tar xz -C /tmp
 sudo mv -v /tmp/eksctl /usr/local/bin
 ```

--- a/content/using_ec2_spot_instances_with_eks/helm_root/install_kube_ops_view.md
+++ b/content/using_ec2_spot_instances_with_eks/helm_root/install_kube_ops_view.md
@@ -79,7 +79,7 @@ helm install --name kube-resource-report \
 --set container.port=8080 \
 --set rbac.create=true \
 --set nodeSelector.intent=control-apps \
-kube-resource-report/chart/kube-resource-report
+kube-resource-report/unsupported/chart/kube-resource-report
 ```
 
 This will install the chart with the right setup, ports and the identification of the label *aws.amazon.com/spot*, that when is defined on a resource, will be used to extract EC2 Spot historic prices associated with the resource. Note that during the rest of the workshop we will still use the `lifecycle` label to identify Spot instances, and only use `aws.amazon.com/spot` to showcase the integration with kube-resource-report. 


### PR DESCRIPTION
close #58

* Upgraded eksctl to 0.18.0
* Changed eksctl command to use `--node-private-networking` to adapt to changes in the default way that managed nodegroups are configured.
https://aws.amazon.com/blogs/containers/upcoming-changes-to-ip-assignment-for-eks-managed-node-groups/
* Changed the directory where kube-resource-report loads from (changes in the structure of the director have moved the helm chart into the directory `unsupported`. The application still works, just means helm is offer as a best effort and has no support from the repo owner @hjacobs).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
