### PR TITLE
fixing the stickiness section in the ASG workshops

### DIFF
--- a/workshops/ec2-auto-scaling-with-multiple-instance-types-and-purchase-options/modify-target-group.json
+++ b/workshops/ec2-auto-scaling-with-multiple-instance-types-and-purchase-options/modify-target-group.json
@@ -7,7 +7,7 @@
     },
     {
       "Key": "stickiness.enabled",
-      "Value": "true"
+      "Value": "false"
     }
   ]
 }

--- a/workshops/running-amazon-ec2-workloads-at-scale/modify-target-group.json
+++ b/workshops/running-amazon-ec2-workloads-at-scale/modify-target-group.json
@@ -7,7 +7,7 @@
     },
     {
       "Key": "stickiness.enabled",
-      "Value": "true"
+      "Value": "false"
     }
   ]
 }


### PR DESCRIPTION
*Issue #, if available:*

Both ASG workshops had the attribute `stickiness.enabled` set to true which clashes with the intent of the workshop and the section where we write:

> Click refresh a few times to see your requests being routed to the different instances deployed behind your load balancer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
