### PR TITLE
FIxing Jenkins module in EKS workshop

### DIFF
--- a/content/using_ec2_spot_instances_with_eks/jenkins/setup_agents.md
+++ b/content/using_ec2_spot_instances_with_eks/jenkins/setup_agents.md
@@ -56,10 +56,11 @@ The creation of the workers will take about 3 minutes.
 #### Instructing Jenkins to run jobs on the new, Spot dedicated nodegroup
 1. In  the Jenkins dashboard, browse to **Manage Jenkins** -> **Manage Node and Clouds**
 1. On the left hand side click on the **Configure Clouds** link. That will take you to the cloud configuration where Kubernetes.
-1. Click on the **Pod Templates...** button to expand the default pod template definition  and then click again on **Pod Template Details...*** 
-1. Change the default pod name, attribute **Name** from `defualt` to `jenkins-agent`. We want to be able to identify the pods that are running in our clusters by name. 
+1. Click on the **Pod Templates...** button to expand the default pod template definition and then click again on **Pod Template Details...*** 
+1. Change the default pod name, attribute **Name** from `defualt` to `jenkins-agent`. We want to be able to identify the pods that are running in our clusters by name.
+1. For the **Command to run** parameter, **remove** the content of the box (/bin/sh -c) - we don't need this custom run command.
 ![Jenkins Pod Setup 1](/images/using_ec2_spot_instances_with_eks/jenkins/jenkinslabels-1.png)
-1. At the bottom of the page, near the end of the Pod template section, In the **Node Selector** Pod , add the following: `intent=jenkins-agents,lifecycle=Ec2Spot`
+1. At the bottom of the page, near the end of the Pod template section, for the **Node Selector** parameter , add the following: `intent=jenkins-agents,lifecycle=Ec2Spot` in order to instruct the Jenkins agent pods to run on the dedicated node group.
 ![Jenkins Pod Setup 2](/images/using_ec2_spot_instances_with_eks/jenkins/jenkinslabels-2.png)
 1. Click **Save**
 

--- a/content/using_ec2_spot_instances_with_eks/jenkins/setup_agents.md
+++ b/content/using_ec2_spot_instances_with_eks/jenkins/setup_agents.md
@@ -34,6 +34,9 @@ nodeGroups:
           k8s.io/cluster-autoscaler/node-template/label/lifecycle: Ec2Spot
           k8s.io/cluster-autoscaler/node-template/label/intent: jenkins-agents
           k8s.io/cluster-autoscaler/node-template/label/aws.amazon.com/spot: "true"
+      iam:
+        withAddonPolicies:
+          autoScaler: true            
 EoF
 ```
 

--- a/content/using_ec2_spot_instances_with_eks/jenkins/setup_jenkins.md
+++ b/content/using_ec2_spot_instances_with_eks/jenkins/setup_jenkins.md
@@ -7,7 +7,7 @@ weight: 30
 #### Install Jenkins
 
 ```
-helm install cicd stable/jenkins --set rbac.create=true,master.servicePort=80,master.serviceType=LoadBalancer
+helm install cicd jenkinsci/jenkins --set rbac.create=true,master.servicePort=80,master.serviceType=LoadBalancer
 ```
 
 The output of this command will give you some additional information such as the


### PR DESCRIPTION
fixes #103 

1. Updating the Helm chart to use the latest jenkinsci version
2. Was missing autoscaler configuration in the eksctl jenkins node group creation command, so the tags for cluster autoscaler auto-discovery were missing
3. Jenkins agent pods were failing to run because the default set up had a bad command in the default "Command to run" option. added instructions to remove it.