### PR TITLE
Log group regexp fix

### DIFF
--- a/workshops/ec2-auto-scaling-with-multiple-instance-types-and-purchase-options/spot-interruption-handler.yaml
+++ b/workshops/ec2-auto-scaling-with-multiple-instance-types-and-purchase-options/spot-interruption-handler.yaml
@@ -85,7 +85,7 @@ Resources:
             Action:
             - logs:CreateLogStream
             - logs:PutLogEvents
-            Resource: arn:aws:logs:*:*:log-group:/aws/lambda/*SpotInterruptionHandlerFunction*:*
+            Resource: arn:aws:logs:*:*:log-group:/aws/lambda/*SpotInterruptionHandlerFunc*:*
           - Effect: Allow
             Action:
             - logs:CreateLogGroup

--- a/workshops/ec2-auto-scaling-with-multiple-instance-types-and-purchase-options/spot-interruption-handler.yaml
+++ b/workshops/ec2-auto-scaling-with-multiple-instance-types-and-purchase-options/spot-interruption-handler.yaml
@@ -16,6 +16,7 @@ Resources:
     DependsOn:
     - LambdaFunctionRole
     Properties:
+      FunctionName: SpotInterruptionHandler
       Handler: index.handler
       Role: !GetAtt LambdaFunctionRole.Arn
       Code:
@@ -85,7 +86,8 @@ Resources:
             Action:
             - logs:CreateLogStream
             - logs:PutLogEvents
-            Resource: arn:aws:logs:*:*:log-group:/aws/lambda/*SpotInterruptionHandlerFunc*:*
+            Resource: 
+              - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/SpotInterruptionHandler:*"
           - Effect: Allow
             Action:
             - logs:CreateLogGroup


### PR DESCRIPTION
Issue #107 

*Description of changes:*

Regexp for log stream name has been shortened from:  `SpotInterruptionHandlerFunction` to `SpotInterruptionHandlerFunc`
Log stream name example : `/aws/lambda/spotinterruptionhandler-SpotInterruptionHandlerFun-1SL0EN5G6I7W0`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
