### PR TITLE
Fix fontawesome css

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM golang:alpine
 
-RUN apk --no-cache --update add git gcc musl-dev g++
-RUN git clone -b 'v0.53' --single-branch --depth 1 https://github.com/gohugoio/hugo.git
-WORKDIR /go/hugo
-RUN go install --tags extended
+RUN apk --no-cache --update add git gcc musl-dev g++ wget
+WORKDIR /tmp
+RUN wget https://github.com/gohugoio/hugo/releases/download/v0.53/hugo_0.53_Linux-64bit.tar.gz && \
+    tar -xf hugo_0.53_Linux-64bit.tar.gz hugo && \
+    rm -rf hugo_0.53_Linux-64bit.tar.gz && \
+    cp hugo /usr/bin/hugo
 WORKDIR /www
 RUN git clone https://github.com/matcornic/hugo-theme-learn/ themes/learn
 COPY . /www/

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
     <link href="{{"css/nucleus.css" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet">
     
     <!-- <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" integrity="sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ" crossorigin="anonymous"> -->
-    <link rel="stylesheet" href="use_fotawesome_com_releases_v5_2_0_css_all.css">  
+    <link rel="stylesheet" href="css/use_fotawesome_com_releases_v5_2_0_css_all.css">  
 
 
     <link href="{{"css/hybrid.css" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet">


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Changing Docker compose/Docker to use download the hugo version instead of installing and compiling it from the scratch; There were some dependencies needed for building it that failed to download when building from the scratch, while this mechanism is equivalent to what the amplify console is doing at this time.
* The local copy of the fontawesome CSS was not pointing to the right directory, as a result fontawesome entries could not be seen (chevron for example). This has now been fixed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
