### PR TITLE
Minor fixes on ECS Spot workshop

### DIFF
--- a/content/ecs-spot-capacity-providers/WorkshopSetup/at_an_aws_stack_name.md
+++ b/content/ecs-spot-capacity-providers/WorkshopSetup/at_an_aws_stack_name.md
@@ -1,0 +1,19 @@
+---
+title: "...At An AWS EVENT - Set Stack Name"
+chapter: false
+disableToc: true
+hidden: true
+---
+
+### Get the stack name that was deployed already
+
+```
+export STACK_NAME=$(aws cloudformation list-stacks | jq -r '.StackSummaries[] | select(.StackName|test("mod.")) | .StackName')
+echo "STACK_NAME=$STACK_NAME"
+```
+
+The output should look something like below.
+
+```
+STACK_NAME=mod-9feefdd1672c4eac
+```

--- a/content/ecs-spot-capacity-providers/WorkshopSetup/cli_setup.md
+++ b/content/ecs-spot-capacity-providers/WorkshopSetup/cli_setup.md
@@ -62,24 +62,15 @@ aws configure get default.region
 
 Use the commands below to set the CloudFormation stack name to an environment variable. 
 
-* If you created the stack manually:
+{{% notice note %}}
+**Select the tab** and follow the specific instructions depending on whether..
+{{% /notice %}}
 
-```
-export STACK_NAME=EcsSpotWorkshop
-```
 
-* If the stack created automatically within Event Engine:
-
-```
-export STACK_NAME=$(aws cloudformation list-stacks | jq -r '.StackSummaries[] | select(.StackName|test("mod.")) | .StackName')
-echo "STACK_NAME=$STACK_NAME"
-```
-
-The output should look something like below.
-
-```
-STACK_NAME=mod-9feefdd1672c4eac
-```
+{{< tabs name="Region" >}}
+    {{< tab name="You created the Stack manually" include="on_your_own_stack_name.md" />}}
+    {{< tab name="Stack already created upfront at an AWS Event" include="at_an_aws_stack_name.md" />}}
+{{< /tabs >}}
 
 
 Run the command below to load CloudFormation outputs as the environment variables.

--- a/content/ecs-spot-capacity-providers/WorkshopSetup/on_your_own_stack_name.md
+++ b/content/ecs-spot-capacity-providers/WorkshopSetup/on_your_own_stack_name.md
@@ -1,0 +1,12 @@
+---
+title: "...ON YOUR OWN - Set Stack Name"
+chapter: false
+disableToc: true
+hidden: true
+---
+
+### Provide the stack name you created earlier
+
+```
+export STACK_NAME=EcsSpotWorkshop
+```

--- a/content/ecs-spot-capacity-providers/WorkshopSetup/resize_ebs.md
+++ b/content/ecs-spot-capacity-providers/WorkshopSetup/resize_ebs.md
@@ -33,14 +33,13 @@ Please make sure changes went through, and the EBS volume now reflects the new s
 
 Changing the block device does not increase the size of the file system.
 
-To do so head back to the Cloud9 instance and use the following commands.
+To do so head back to the Cloud9 instance and use the following commands to reboot the instance. It could take a minute or two for the IDE to come back online.
 
 ```
-sudo growpart /dev/xvda 1
-sudo resize2fs $(df -h |awk '/^\/dev/{print $1}')
+sudo reboot
 ```
 
-The root file-system should now show 99GB.
+The root file-system should now show 100GB.
 
 ```
 df --human-readable
@@ -48,7 +47,9 @@ df --human-readable
 
 ```plaintext
 Filesystem      Size  Used Avail Use% Mounted on
-devtmpfs        483M   60K  483M   1% /dev
-tmpfs           493M     0  493M   0% /dev/shm
-/dev/xvda1       99G  8.0G   91G   9% /
+devtmpfs        960M     0  960M   0% /dev
+tmpfs           978M     0  978M   0% /dev/shm
+tmpfs           978M  452K  978M   1% /run
+tmpfs           978M     0  978M   0% /sys/fs/cgroup
+/dev/nvme0n1p1  100G  8.5G   92G   9% /
 ```

--- a/content/ecs-spot-capacity-providers/module-1/asg_with_od.md
+++ b/content/ecs-spot-capacity-providers/module-1/asg_with_od.md
@@ -17,7 +17,7 @@ substituting the CloudFormation environment variables that we exported earlier w
 ```
 export ASG_NAME=EcsSpotWorkshop-ASG-OD
 export OD_PERCENTAGE=100 # Note that ASG will have 100% On-Demand, 0% Spot
-sed -i -e "s#%ASG_NAME%#$ASG_NAME#g" -e "s#%OD_PERCENTAGE%#$OD_PERCENTAGE#g" -e "s#%PUBLIC_SUBNET_LIST%#$VPCPublicSubnets#g" asg.json
+sed -i -e "s#%ASG_NAME%#$ASG_NAME#g" -e "s#%OD_PERCENTAGE%#$OD_PERCENTAGE#g" -e "s#%PUBLIC_SUBNET_LIST%#$VPCPublicSubnets#g" -e "s#%LAUNCH_TEMPLATE_ID%#$LaunchTemplateId#g" asg.json
 ```
 {{% notice info%}}
 Read the **asg.json** file and understand the various configuration options for the EC2 Auto Scaling group. Check how although this is an OnDemand we still apply instance diversification with the Prioritized allocation strategy. Check how the **Launch Template** we reviewed in the previous section is referenced in the Auto Scaling Group.

--- a/content/ecs-spot-capacity-providers/module-1/asg_with_spot.md
+++ b/content/ecs-spot-capacity-providers/module-1/asg_with_spot.md
@@ -24,7 +24,7 @@ We will now replace the environment variables in the spot-asg.json file with the
 ```
 export ASG_NAME=EcsSpotWorkshop-ASG-SPOT
 export OD_PERCENTAGE=0 # Note that ASG will have 0% On-Demand, 100% Spot
-sed -i -e "s#%ASG_NAME%#$ASG_NAME#g"  -e "s#%OD_PERCENTAGE%#$OD_PERCENTAGE#g" -e "s#%PUBLIC_SUBNET_LIST%#$VPCPublicSubnets#g" spot-asg.json
+sed -i -e "s#%ASG_NAME%#$ASG_NAME#g"  -e "s#%OD_PERCENTAGE%#$OD_PERCENTAGE#g" -e "s#%PUBLIC_SUBNET_LIST%#$VPCPublicSubnets#g" -e "s#%LAUNCH_TEMPLATE_ID%#$LaunchTemplateId#g" spot-asg.json
 ```
 
 Finally we create the ASG for the Spot Instances and store the ARN for the spot group.

--- a/content/ecs-spot-capacity-providers/module-1/create_ecs_cluster.md
+++ b/content/ecs-spot-capacity-providers/module-1/create_ecs_cluster.md
@@ -17,6 +17,10 @@ Let us first create an empty ECS cluster.To create an ECS cluster, follow these 
 * Select the checkbox **Create an empty cluster**
 * Select the checkbox **Enable Container Insights**
 
+{{% notice note %}}
+If you are using a different name for the cluster than **EcsSpotWorkshop**, please make sure you update the Launch template ecs agent bootstrapping. Learn more about ECS agent bootstrapping [here] (#ecs-agent-bootstrapping)   
+{{% /notice %}}
+
 ![ECS Cluster](/images/ecs-spot-capacity-providers/ecs_create_cluster.png)
 
 * Click **Create**
@@ -31,7 +35,7 @@ The new ECS cluster will appear as below in the AWS Console.
 **CloudWatch Container Insights** collects, aggregates, and summarizes metrics and logs from your containerized applications and microservices. It collects metrics for many resources, such as CPU, memory, disk, and network. Container Insights is available for Amazon Elastic Container Service (Amazon ECS), Amazon Elastic Kubernetes Service (Amazon EKS), and Kubernetes platforms on Amazon EC2. Amazon ECS support includes support for Fargate. You can **[read more about CloudWatch Container Insights here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html)**. 
 {{% /notice %}}
 
-# Launch Templates & ECS Agent Bootstrapping
+# Launch Templates & ECS Agent Bootstrapping {#ecs-agent-bootstrapping}
 
 {{% notice info %}}
 Launch Template **User Data** section is key in ECS for actions such as **[bootstrapping container instances](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bootstrap_container_instance.html)** and **[configuring the ECS agent](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html)** 

--- a/workshops/ecs-spot-capacity-providers/templates/asg.json
+++ b/workshops/ecs-spot-capacity-providers/templates/asg.json
@@ -3,7 +3,7 @@
   "MixedInstancesPolicy": {
     "LaunchTemplate": {
       "LaunchTemplateSpecification": {
-        "LaunchTemplateName": "EcsSpotWorkshop",
+        "LaunchTemplateId": "%LAUNCH_TEMPLATE_ID%",
         "Version": "1"
       },
       "Overrides": [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Removed the hard coded LaunchTeplateName and updated to use the LaunchTemplateId populated from stack outputs.
2. Added an info about the need to update the Launch template if a different name for the cluster than EcsSpotWorkshop is used.
3. Resizing the EBS volume fails for nitro instances. Added a reboot which will automatically grow the fs.
4. Setting the Stack name before exporting the Cloudformation outputs is now in multiple tabs to avoid confusion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
