### PR TITLE
upgraded to Karpenter 0.10.0, missing FIS, Grafana y Queue NTH mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN wget https://github.com/gohugoio/hugo/releases/download/v0.92.0/hugo_0.92.0_
     tar -xf hugo_0.92.0_Linux-64bit.tar.gz hugo && \
     rm -rf hugo_0.92.0_Linux-64bit.tar.gz && \
     cp hugo /usr/bin/hugo
-WORKDIR /www
-RUN git clone https://github.com/matcornic/hugo-theme-learn/ themes/learn
+WORKDIR /www/
 COPY . /www/
+RUN rm -rf themes/learn && git clone https://github.com/matcornic/hugo-theme-learn/ themes/learn
 ENTRYPOINT ["hugo", "server", "--bind", "0.0.0.0"]
 CMD [""]

--- a/content/karpenter/040_karpenter/advanced_provisioner.md
+++ b/content/karpenter/040_karpenter/advanced_provisioner.md
@@ -116,17 +116,17 @@ kubectl describe provisioners default
 ## (Optional Read) Customizing AMIs and Node Bootstrapping 
 
 {{% notice info %}}
-In this workshop we will stick to the default AMI's used by Karpenter. This section does not contain any exercise or command. The section describes how the AMI and node bootsrapping can be adapted when needed. If you want to deep dive into this topic you can [read the following karpenter documentation link](https://karpenter.sh/v0.6.5/aws/launch-templates/)
+In this workshop we will stick to the default AMI's used by Karpenter. This section does not contain any exercise or command. The section describes how the AMI and node bootsrapping can be adapted when needed. If you want to deep dive into this topic you can [read the following karpenter documentation link](https://karpenter.sh/v0.10.0/aws/launch-templates/)
 {{% /notice %}}
 
-By default, Karpenter generates [launch templates](https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html) that use [EKS Optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html) for nodes. Often, users need to customize the node image to integrate with existing infrastructure, meet compliance requirements, add extra storage, etc. Karpenter supports custom node images and bootsrapping through Launch Templates. If you need to customize the node, then you need a custom launch template. 
+By default, Karpenter generates [launch templates](https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html) that use [EKS Optimized AMI](https://docs.aws.amazon.com/eks/latest/userguide/eks-optimized-ami.html) and Encrypted EBS root volumes with the default (AWS Managed) KMS key for nodes. Often, users need to customize the node image to integrate with existing infrastructure, meet compliance requirements, add extra storage, etc. Karpenter supports custom node images and bootsrapping through Launch Templates. If you need to customize the node, then you need a custom launch template. 
 
 {{%notice note %}}
 Using custom launch templates prevents multi-architecture support, the ability to automatically upgrade nodes, and securityGroup discovery. Using launch templates may also cause confusion because certain fields are duplicated within Karpenter’s provisioners while others are ignored by Karpenter, e.g. subnets and instance types.
 {{% /notice%}}
 
 {{% notice warning %}}
-By customizing the image, you are taking responsibility for maintaining it, including security updates. In the default configuration, Karpenter will use the latest version of the EKS optimized AMI, which is maintained by AWS. 
+By customizing the image, you are taking responsibility for maintaining it, including security updates. In the default configuration, Karpenter will use the latest version of the EKS optimized AMI, which is maintained by AWS.
 {{% /notice %}}
 
 
@@ -149,7 +149,4 @@ when building a custom base image.
 {{% notice warning %}}
 Specifying max-pods can break Karpenter's bin-packing logic (it has no way to know what this setting is). If Karpenter attempts to pack more than this number of pods, the instance may be oversized, and additional pods will reschedule.
 {{% /notice %}}
-
-
-
 

--- a/content/karpenter/040_karpenter/ec2_spot_deployments.md
+++ b/content/karpenter/040_karpenter/ec2_spot_deployments.md
@@ -24,7 +24,7 @@ To deploy the Node Termination Handler run the following command:
 helm repo add eks https://aws.github.io/eks-charts
 helm install aws-node-termination-handler \
              --namespace kube-system \
-             --version 0.16.0 \
+             --version 0.18.3 \
              --set nodeSelector."karpenter\\.sh/capacity-type"=spot \
              eks/aws-node-termination-handler
 ```

--- a/content/karpenter/040_karpenter/multiple_architectures.md
+++ b/content/karpenter/040_karpenter/multiple_architectures.md
@@ -124,12 +124,15 @@ The output should show something similar to the lines below
 
 ```bash
 ...
-2021-11-16T00:43:22.773Z        INFO    controller.allocation.provisioner/default       Starting provisioning loop      {"commit": "6468992"}
-2021-11-16T00:43:22.773Z        INFO    controller.allocation.provisioner/default       Waiting to batch additional pods        {"commit": "6468992"}
-2021-11-16T00:43:23.976Z        INFO    controller.allocation.provisioner/default       Found 2 provisionable pods      {"commit": "6468992"}
-2021-11-16T00:43:25.034Z        INFO    controller.allocation.provisioner/default       Computed packing for 2 pod(s) with instance type option(s) [c5a.xlarge c5d.xlarge c3.xlarge c4.xlarge c5ad.xlarge c5.xlarge c6i.xlarge c1.xlarge c5n.xlarge m1.xlarge m3.xlarge t3.xlarge t3a.xlarge m5dn.xlarge m5ad.xlarge m4.xlarge m5zn.xlarge m5n.xlarge m6i.xlarge m5d.xlarge]        {"commit": "6468992"}
-2021-11-16T00:43:27.038Z        INFO    controller.allocation.provisioner/default       Launched instance: i-0e4b58e5fbdc8eeb8, hostname: xxxxxxxxxxxxxxxxxxx.compute.internal, type: t3a.xlarge, zone: eu-west-1a, capacityType: on-demand    {"commit": "6468992"}
-2021-11-16T00:43:27.057Z        INFO    controller.allocation.provisioner/default       Bound 2 pod(s) to node xxxxxxxxxxxxxxxxxxx.compute.internal   {"commit": "6468992"}
+2022-05-12T04:15:10.593Z        INFO    controller      Batched 2 pod(s) in 1.009818195s        {"commit": "00661aa"}
+2022-05-12T04:15:10.770Z        DEBUG   controller      Discovered subnets: [subnet-0204b1b3b885ca98d (eu-west-1a) subnet-037d1d97a6a473fd1 (eu-west-1b) subnet-04c2ca248972479e7 (eu-west-1b) subnet-063d5c7ba912986d5 (eu-west-1a)]   {"commit": "00661aa"}
+2022-05-12T04:15:10.851Z        DEBUG   controller      Discovered security groups: [sg-03ab1d5d49b00b596 sg-06e7e2ca961ab3bed]{"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:15:10.854Z        DEBUG   controller      Discovered kubernetes version 1.21      {"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:15:10.940Z        DEBUG   controller      Discovered ami-0440c10a3f77514d8 for query "/aws/service/eks/optimized-ami/1.21/amazon-linux-2/recommended/image_id"    {"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:15:10.977Z        DEBUG   controller      Discovered launch template Karpenter-eksworkshop-eksctl-13001267661656074018    {"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:15:13.081Z        INFO    controller      Launched instance: i-0d19d3eeb2d59578d, hostname: ip-192-168-22-165.eu-west-1.compute.internal, type: m4.xlarge, zone: eu-west-1a, capacityType: spot   {"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:15:13.093Z        INFO    controller      Created node with 2 pods requesting {"cpu":"2125m","memory":"512M","pods":"5"} from types c4.xlarge, c6i.xlarge, c5a.xlarge, c5.xlarge, c6a.xlarge and 267 other(s)     {"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:15:13.103Z        INFO    controller      Waiting for unschedulable pods  {"commit": "00661aa"}
 ...
 ```
 
@@ -199,10 +202,17 @@ The output should show something similar to the lines below
 
 ```bash
 ...
-2021-11-30T19:21:52.786Z        INFO    controller.provisioning Batched 2 pods in 1.030167637s  {"commit": "84b683b", "provisioner": "default"}
-2021-11-30T19:21:52.791Z        INFO    controller.provisioning Computed packing of 1 node(s) for 2 pod(s) with instance type option(s) [c6g.xlarge]    {"commit": "84b683b", "provisioner": "default"}
-2021-11-30T19:21:55.764Z        INFO    controller.provisioning Launched instance: i-0fe8ef259d1e0bf83, hostname: ip-192-168-77-232.us-west-2.compute.internal, type: c6g.xlarge, zone: us-west-2a, capacityType: on-demand     {"commit": "84b683b", "provisioner": "default"}
-2021-11-30T19:21:55.865Z        INFO    controller.provisioning Bound 2 pod(s) to node ip-192-168-77-232.us-west-2.compute.internal     {"commit": "84b683b", "provisioner": "default"}
+2022-05-12T04:20:51.896Z        INFO    controller      Batched 2 pod(s) in 1.014499438s        {"commit": "00661aa"}
+2022-05-12T04:20:52.665Z        DEBUG   controller      Discovered 401 EC2 instance types       {"commit": "00661aa"}
+2022-05-12T04:20:52.790Z        DEBUG   controller      Discovered EC2 instance types zonal offerings   {"commit": "00661aa"}
+2022-05-12T04:20:52.960Z        DEBUG   controller      Discovered subnets: [subnet-0204b1b3b885ca98d (eu-west-1a) subnet-037d1d97a6a473fd1 (eu-west-1b) subnet-04c2ca248972479e7 (eu-west-1b) subnet-063d5c7ba912986d5 (eu-west-1a)]   {"commit": "00661aa"}
+2022-05-12T04:20:53.055Z        DEBUG   controller      Discovered security groups: [sg-03ab1d5d49b00b596 sg-06e7e2ca961ab3bed]{"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:20:53.071Z        DEBUG   controller      Discovered kubernetes version 1.21      {"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:20:53.140Z        DEBUG   controller      Discovered ami-05dc8c3028bc33fd6 for query "/aws/service/eks/optimized-ami/1.21/amazon-linux-2-arm64/recommended/image_id"      {"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:20:53.310Z        DEBUG   controller      Created launch template, Karpenter-eksworkshop-eksctl-13655185630813568172      {"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:20:55.201Z        INFO    controller      Launched instance: i-013c73aa33c952ace, hostname: ip-192-168-60-157.eu-west-1.compute.internal, type: c6g.xlarge, zone: eu-west-1b, capacityType: spot  {"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:20:55.214Z        INFO    controller      Created node with 2 pods requesting {"cpu":"2125m","memory":"512M","pods":"5"} from types c6g.xlarge    {"commit": "00661aa", "provisioner": "default"}
+2022-05-12T04:20:55.229Z        INFO    controller      Waiting for unschedulable pods  {"commit": "00661aa"}
 ...
 ```
 

--- a/content/karpenter/040_karpenter/set_up_the_environment.md
+++ b/content/karpenter/040_karpenter/set_up_the_environment.md
@@ -12,10 +12,10 @@ Before we install Karpenter, there are a few things that we will need to prepare
 Instances launched by Karpenter must run with an InstanceProfile that grants permissions necessary to run containers and configure networking. Karpenter discovers the InstanceProfile using the name `KarpenterNodeRole-${ClusterName}`.
 
 ```
-export KARPENTER_VERSION=v0.6.4
+export KARPENTER_VERSION=v0.10.0
 echo "export KARPENTER_VERSION=${KARPENTER_VERSION}" >> ~/.bash_profile
 TEMPOUT=$(mktemp)
-curl -fsSL https://karpenter.sh/"${KARPENTER_VERSION}"/getting-started/cloudformation.yaml > $TEMPOUT \
+curl -fsSL https://karpenter.sh/"${KARPENTER_VERSION}"/getting-started/getting-started-with-eksctl/cloudformation.yaml > $TEMPOUT \
 && aws cloudformation deploy \
   --stack-name Karpenter-${CLUSTER_NAME} \
   --template-file ${TEMPOUT} \
@@ -24,7 +24,7 @@ curl -fsSL https://karpenter.sh/"${KARPENTER_VERSION}"/getting-started/cloudform
 ```
 
 {{% notice tip %}}
-This step may take about 2 minutes. In the meantime, you can [download the file](https://karpenter.sh/v0.6.4/getting-started/cloudformation.yaml) and check the content of the CloudFormation Stack. Check how the stack defines a policy, a role and and Instance profile that will be used to associate to the instances launched. You can also head to the **CloudFormation** console and check which resources does the stack deploy.
+This step may take about 2 minutes. In the meantime, you can [download the file](https://karpenter.sh/v0.10.0/getting-started/getting-started-with-eksctl/cloudformation.yaml) and check the content of the CloudFormation Stack. Check how the stack defines a policy, a role and and Instance profile that will be used to associate to the instances launched. You can also head to the **CloudFormation** console and check which resources does the stack deploy.
 {{% /notice %}}
 
 Second, grant access to instances using the profile to connect to the cluster. This command adds the Karpenter node role to your aws-auth configmap, allowing nodes with this role to connect to the cluster.
@@ -78,6 +78,3 @@ This step is only necessary if this is the first time you’re using EC2 Spot in
 ```
 aws iam create-service-linked-role --aws-service-name spot.amazonaws.com
 ```
-
-
-

--- a/content/karpenter/040_karpenter/set_up_the_provisioner.md
+++ b/content/karpenter/040_karpenter/set_up_the_provisioner.md
@@ -60,7 +60,7 @@ The configuration for this provider is quite simple. We will change in the futur
 
 
 {{% notice info %}}
-Karpenter has been designed to be generic and support other Cloud and Infrastructure providers. At the moment of writing this workshop (Karpenter 0.6.4) main implementation and Provisioner available is on AWS. You can read more about the **[configuration available for the AWS Provisioner here](https://karpenter.sh/v0.6.5/aws/)**
+Karpenter has been designed to be generic and support other Cloud and Infrastructure providers. At the moment of writing this workshop (**Karpenter 0.10.0**) main implementation and Provisioner available is on AWS. You can read more about the **[configuration available for the AWS Provisioner here](https://karpenter.sh/v0.10.0/aws/)**
 {{% /notice %}}
 
 ## Displaying Karpenter Logs

--- a/content/karpenter/040_karpenter/using_alternative_provisioners.md
+++ b/content/karpenter/040_karpenter/using_alternative_provisioners.md
@@ -51,7 +51,7 @@ spec:
       - labelSelector:
           matchLabels:
             app: inflate-team1
-        maxSkew: 100
+        maxSkew: 1
         topologyKey: topology.kubernetes.io/zone
         whenUnsatisfiable: ScheduleAnyway
 EOF
@@ -132,15 +132,19 @@ The output of Karpenter should look similar to the one below
 
 ```
 ...
-2021-11-16T05:41:30.292Z        INFO    controller.allocation.provisioner/team1 Starting provisioning loop      {"commit": "6468992"}
-2021-11-16T05:41:30.293Z        INFO    controller.allocation.provisioner/team1 Waiting to batch additional pods        {"commit": "6468992"}
-2021-11-16T05:41:31.476Z        INFO    controller.allocation.provisioner/team1 Found 4 provisionable pods      {"commit": "6468992"}
-2021-11-16T05:41:32.490Z        INFO    controller.allocation.provisioner/team1 Computed packing for 2 pod(s) with instance type option(s) [c5.xlarge c6i.xlarge c3.xlarge c5a.xlarge c5d.xlarge c4.xlarge c1.xlarge c5n.xlarge m3.xlarge m1.xlarge m6i.xlarge m5zn.xlarge m5.xlarge m4.xlarge m5ad.xlarge m5d.xlarge t3.xlarge m5dn.xlarge m5a.xlarge t3a.xlarge]  {"commit": "6468992"}
-2021-11-16T05:41:32.509Z        INFO    controller.allocation.provisioner/team1 Computed packing for 2 pod(s) with instance type option(s) [c6i.xlarge c5.xlarge c4.xlarge c5a.xlarge c5ad.xlarge c5d.xlarge c3.xlarge c1.xlarge c5n.xlarge m1.xlarge m3.xlarge m5zn.xlarge m5.xlarge m6i.xlarge t3a.xlarge m5ad.xlarge m5a.xlarge t3.xlarge m5dn.xlarge m5n.xlarge]        {"commit": "6468992"}
-2021-11-16T05:41:34.216Z        INFO    controller.allocation.provisioner/team1 Launched instance: i-0f92acfe9a25a80c4, hostname: xxxxxxxxxxxxxxxxxxxxxxxxxxx.compute.internal, type: t3a.xlarge, zone: eu-west-1a, capacityType: on-demand   {"commit": "6468992"}
-2021-11-16T05:41:34.242Z        INFO    controller.allocation.provisioner/team1 Bound 2 pod(s) to node xxxxxxxxxxxxxxxxxxxxxxxxxxx.compute.internal     {"commit": "6468992"}
-2021-11-16T05:41:34.305Z        INFO    controller.allocation.provisioner/team1 Launched instance: i-02adc32c53c19fcec, hostname: xxxxxxxxxxxxxxxxxxxxxxxxxxxx.compute.internal, type: t3a.xlarge, zone: eu-west-1b, capacityType: on-demand  {"commit": "6468992"}
-2021-11-16T05:41:34.335Z        INFO    controller.allocation.provisioner/team1 Bound 2 pod(s) to node xxxxxxxxxxxxxxxxxxxxxxxxxxxx.compute.internal    {"commit": "6468992"}
+2022-05-12T04:33:28.625Z        INFO    controller      Batched 4 pod(s) in 1.038819076s        {"commit": "00661aa"}
+2022-05-12T04:33:29.361Z        DEBUG   controller      Discovered 401 EC2 instance types       {"commit": "00661aa"}
+2022-05-12T04:33:29.482Z        DEBUG   controller      Discovered EC2 instance types zonal offerings   {"commit": "00661aa"}
+2022-05-12T04:33:29.638Z        DEBUG   controller      Discovered subnets: [subnet-0204b1b3b885ca98d (eu-west-1a) subnet-037d1d97a6a473fd1 (eu-west-1b) subnet-04c2ca248972479e7 (eu-west-1b) subnet-063d5c7ba912986d5 (eu-west-1a)]     {"commit": "00661aa"}
+2022-05-12T04:33:29.728Z        DEBUG   controller      Discovered security groups: [sg-03ab1d5d49b00b596 sg-06e7e2ca961ab3bed]  {"commit": "00661aa", "provisioner": "team1"}
+2022-05-12T04:33:29.732Z        DEBUG   controller      Discovered kubernetes version 1.21      {"commit": "00661aa", "provisioner": "team1"}
+2022-05-12T04:33:29.796Z        DEBUG   controller      Discovered ami-0440c10a3f77514d8 for query "/aws/service/eks/optimized-ami/1.21/amazon-linux-2/recommended/image_id"     {"commit": "00661aa", "provisioner": "team1"}
+2022-05-12T04:33:29.971Z        DEBUG   controller      Created launch template, Karpenter-eksworkshop-eksctl-2228580094236845875        {"commit": "00661aa", "provisioner": "team1"}
+2022-05-12T04:33:31.885Z        INFO    controller      Launched instance: i-02df8ea1e99895e78, hostname: ip-192- 68-14-13.eu-west-1.compute.internal, type: t3a.xlarge, zone: eu-west-1a, capacityType: on-demand       {"commit": "00661aa", "provisioner": "team1"}
+2022-05-12T04:33:31.896Z        INFO    controller      Created node with 2 pods requesting {"cpu":"2125m","memory":"512M","pods":"4"} from types c4.xlarge, c6a.xlarge, c6i.xlarge, c5.xlarge, c5a.xlarge and 263 other(s)      {"commit": "00661aa", "provisioner": "team1"}
+2022-05-12T04:33:32.443Z        INFO    controller      Launched instance: i-0b6984823f26d5b15, hostname: ip-192-168-39-218.eu-west-1.compute.internal, type: t3a.xlarge, zone: eu-west-1b, capacityType: on-demand      {"commit": "00661aa", "provisioner": "team1"}
+2022-05-12T04:33:32.453Z        INFO    controller      Created node with 2 pods requesting {"cpu":"2125m","memory":"512M","pods":"4"} from types c4.xlarge, c6a.xlarge, c6i.xlarge, c5.xlarge, c5a.xlarge and 267 other(s)      {"commit": "00661aa", "provisioner": "team1"}
+2022-05-12T04:33:32.464Z        INFO    controller      Waiting for unschedulable pods  {"commit": "00661aa"}
 ...
 ```
 


### PR DESCRIPTION
*Issue #, if available:*

Karpenter has been updated to 0.10.0 a few of the new functionality highlighted and a few other changes to adapt to new Karpenter behaviour. This is the first of two PR's coming to update Karpenter. The next session, 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
