### PR TITLE
Fix for Flask dependency error

### DIFF
--- a/workshops/ecs-spot-capacity-providers/webapp/requirements.txt
+++ b/workshops/ecs-spot-capacity-providers/webapp/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.2
+Flask==2.1.0
 Flask-Cors
 requests
 signals


### PR DESCRIPTION
With the current dependency the container is failing due to a Flask dependency error.

ImportError: cannot import name 'escape' from 'jinja2'

*Issue #, if available:*

*Description of changes:* Changed the Flask dependency version to fix the container


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
