### PR TITLE
Fix Karpenter workshop - failure to install kube-ops-view and Karpenter helm chart

### DIFF
--- a/content/karpenter/030_k8s_tools/helm_deploy.md
+++ b/content/karpenter/030_k8s_tools/helm_deploy.md
@@ -25,6 +25,7 @@ Before we can get started configuring Helm, we'll need to first install the
 command line tools that you will interact with. To do this, run the following:
 
 ```
+export DESIRED_VERSION=v3.8.2
 curl -sSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
 ```
 


### PR DESCRIPTION
*Description of changes:*

Pinning the version of helm to fix https://github.com/awslabs/ec2-spot-workshops/issues/195

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
