### PR TITLE
Updated Lambda python runtime version as Python 3.6 is deprecated

### DIFF
--- a/content/using_ec2_spot_instances_with_eks/010_prerequisites/prerequisites.files/eks-spot-workshop-quickstart-cnf.yml
+++ b/content/using_ec2_spot_instances_with_eks/010_prerequisites/prerequisites.files/eks-spot-workshop-quickstart-cnf.yml
@@ -160,7 +160,7 @@ Resources:
         Fn::GetAtt:
         - C9LambdaExecutionRole
         - Arn
-      Runtime: python3.6
+      Runtime: python3.9
       MemorySize: 256
       Timeout: '600'
       Code:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Updated Lambda python runtime version as Python 3.6 is deprecated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
