### PR TITLE
Updating the CFN for Tracking Spot notifications and use the latest EC2 Instance Selector CLI version

### DIFF
--- a/content/running_spark_apps_with_emr_on_spot_instances/selecting_instance_types.md
+++ b/content/running_spark_apps_with_emr_on_spot_instances/selecting_instance_types.md
@@ -17,7 +17,7 @@ types with sufficient number of vCPUs and RAM.
 Let's first install amazon-ec2-instance-selector on Cloud9 IDE:
 
 ```
-curl -Lo ec2-instance-selector https://github.com/aws/amazon-ec2-instance-selector/releases/download/v2.3.2/ec2-instance-selector-`uname | tr '[:upper:]' '[:lower:]'`-amd64 && chmod +x ec2-instance-selector
+curl -Lo ec2-instance-selector https://github.com/aws/amazon-ec2-instance-selector/releases/download/v2.4.0/ec2-instance-selector-`uname | tr '[:upper:]' '[:lower:]'`-amd64 && chmod +x ec2-instance-selector
 sudo mv ec2-instance-selector /usr/local/bin/
 ec2-instance-selector --version
 ```

--- a/workshops/track-spot-interruptions/cloudwatchlogs.yaml
+++ b/workshops/track-spot-interruptions/cloudwatchlogs.yaml
@@ -21,7 +21,6 @@ Resources:
         detail-type:
         - EC2 Instance Rebalance Recommendation
       State: ENABLED
-      RoleArn: !GetAtt CloudWatchLogRole.Arn
       Targets:
       - Arn:
           Fn::GetAtt:
@@ -40,7 +39,6 @@ Resources:
         detail-type:
         - EC2 Spot Instance Interruption Warning
       State: ENABLED
-      RoleArn: !GetAtt CloudWatchLogRole.Arn
       Targets:
       - Arn:
           Fn::GetAtt:
@@ -56,25 +54,33 @@ Resources:
         Ref: CloudWatchLogGroupName
       RetentionInDays:
         Ref: CloudWatchLogGroupRetentionPeriodDays
-  CloudWatchLogRole:
-    Type: AWS::IAM::Role
+  LogGroupForEventsPolicy:
+    Type: AWS::Logs::ResourcePolicy
     Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service: events.amazonaws.com
-            Action: 'sts:AssumeRole'
-      Policies:
-      -   PolicyName: "AllowLogging"
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: "Allow"
-                Action:
-                  - 'logs:*'
-                Resource: "*"
+      PolicyName: EventBridgeToCWLogsPolicy
+      PolicyDocument: !Sub >
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "EventBridgetoCWLogsCreateLogStreamPolicy",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "events.amazonaws.com",
+                  "delivery.logs.amazonaws.com"
+                ]
+              },
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+              ],
+              "Resource": [
+                "${CloudWatchLogGroup.Arn}"
+              ]
+            }
+          ]
+        }
 
 Outputs:
   CloudWatchLogGroupName:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* There's a missing resource in the CFN used for tracking Spot notifications into CloudWatch, especially for new accounts that have never been enable tracking trough EventBridge to CloudWatch in the console. I'm also including an update to use the latest version of the EC2 Instance Selector CLI to use the updated list of instance types for EMR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
