### PR TITLE
fix: update Karpenter version to v0.22.1

### DIFF
--- a/content/karpenter/050_karpenter/set_up_the_environment.md
+++ b/content/karpenter/050_karpenter/set_up_the_environment.md
@@ -14,7 +14,7 @@ Instances launched by Karpenter must run with an InstanceProfile that grants per
 Karpenter also utilizes an SQS queue and EventBridge rules to handle Spot Interruption Notifications and AWS Health Events.
 
 ```
-export KARPENTER_VERSION=v0.19.3
+export KARPENTER_VERSION=v0.22.1
 echo "export KARPENTER_VERSION=${KARPENTER_VERSION}" >> ~/.bash_profile
 TEMPOUT=$(mktemp)
 curl -fsSL https://karpenter.sh/"${KARPENTER_VERSION}"/getting-started/getting-started-with-eksctl/cloudformation.yaml > $TEMPOUT \
@@ -26,7 +26,7 @@ curl -fsSL https://karpenter.sh/"${KARPENTER_VERSION}"/getting-started/getting-s
 ```
 
 {{% notice tip %}}
-This step may take about 2 minutes. In the meantime, you can [download the file](https://karpenter.sh/v0.19.2/getting-started/getting-started-with-eksctl/cloudformation.yaml) and check the content of the CloudFormation Stack. Check how the stack defines a policy, a role and and Instance profile that will be used to associate to the instances launched. You can also head to the **CloudFormation** console and check which resources does the stack deploy.
+This step may take about 2 minutes. In the meantime, you can [download the file](https://karpenter.sh/v0.22.1/getting-started/getting-started-with-eksctl/cloudformation.yaml) and check the content of the CloudFormation Stack. Check how the stack defines a policy, a role and and Instance profile that will be used to associate to the instances launched. You can also head to the **CloudFormation** console and check which resources does the stack deploy.
 {{% /notice %}}
 
 Second, grant access to instances using the profile to connect to the cluster. This command adds the Karpenter node role to your aws-auth configmap, allowing nodes with this role to connect to the cluster.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update Karpenter version to v0.22.1 to fix links as the v0.19.3 doc it links to no longer exists.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
