### PR TITLE
Updating Karpenter version from 0.23.0 to 0.26.1

### DIFF
--- a/content/karpenter/050_karpenter/set_up_the_environment.md
+++ b/content/karpenter/050_karpenter/set_up_the_environment.md
@@ -14,7 +14,7 @@ Instances launched by Karpenter must run with an InstanceProfile that grants per
 Karpenter also utilizes an SQS queue and EventBridge rules to handle Spot Interruption Notifications and AWS Health Events.
 
 ```
-export KARPENTER_VERSION=v0.23.0
+export KARPENTER_VERSION=v0.26.1
 echo "export KARPENTER_VERSION=${KARPENTER_VERSION}" >> ~/.bash_profile
 TEMPOUT=$(mktemp)
 curl -fsSL https://karpenter.sh/"${KARPENTER_VERSION}"/getting-started/getting-started-with-eksctl/cloudformation.yaml > $TEMPOUT \

--- a/content/karpenter/050_karpenter/set_up_the_environment.md
+++ b/content/karpenter/050_karpenter/set_up_the_environment.md
@@ -26,7 +26,7 @@ curl -fsSL https://karpenter.sh/"${KARPENTER_VERSION}"/getting-started/getting-s
 ```
 
 {{% notice tip %}}
-This step may take about 2 minutes. In the meantime, you can [download the file](https://karpenter.sh/v0.22.1/getting-started/getting-started-with-eksctl/cloudformation.yaml) and check the content of the CloudFormation Stack. Check how the stack defines a policy, a role and and Instance profile that will be used to associate to the instances launched. You can also head to the **CloudFormation** console and check which resources does the stack deploy.
+This step may take about 2 minutes. In the meantime, you can [download the file](https://karpenter.sh/v0.26.1/getting-started/getting-started-with-eksctl/cloudformation.yaml) and check the content of the CloudFormation Stack. Check how the stack defines a policy, a role and and Instance profile that will be used to associate to the instances launched. You can also head to the **CloudFormation** console and check which resources does the stack deploy.
 {{% /notice %}}
 
 Second, grant access to instances using the profile to connect to the cluster. This command adds the Karpenter node role to your aws-auth configmap, allowing nodes with this role to connect to the cluster.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The url to download the cloudformation.yaml file is no longer available under the version v0.23.0 as per link https://karpenter.sh/v0.23.0/getting-started/getting-started-with-eksctl/cloudformation.yaml.

I have updated the Karpenter version to 0.26.1 (the current latest version) and able to download and proceed with the workshop https://karpenter.sh/v0.26.1/getting-started/getting-started-with-eksctl/cloudformation.yaml. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
