### PR TITLE
Update eks-blueprints.tf terraform version of VPC module

### DIFF
--- a/content/using_ec2_spot_instances_with_eks/010_prerequisites/prerequisites.files/eks-blueprints.tf
+++ b/content/using_ec2_spot_instances_with_eks/010_prerequisites/prerequisites.files/eks-blueprints.tf
@@ -159,7 +159,7 @@ module "eks_blueprints_kubernetes_addons" {
 #---------------------------------------------------------------
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 4.0.2"
+  version = "4.0.2"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/content/using_ec2_spot_instances_with_eks/010_prerequisites/prerequisites.files/eks-blueprints.tf
+++ b/content/using_ec2_spot_instances_with_eks/010_prerequisites/prerequisites.files/eks-blueprints.tf
@@ -159,7 +159,7 @@ module "eks_blueprints_kubernetes_addons" {
 #---------------------------------------------------------------
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 4.0"
 
   name = local.name
   cidr = local.vpc_cidr

--- a/content/using_ec2_spot_instances_with_eks/010_prerequisites/prerequisites.files/eks-blueprints.tf
+++ b/content/using_ec2_spot_instances_with_eks/010_prerequisites/prerequisites.files/eks-blueprints.tf
@@ -159,7 +159,7 @@ module "eks_blueprints_kubernetes_addons" {
 #---------------------------------------------------------------
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 4.0"
+  version = "~> 4.0.2"
 
   name = local.name
   cidr = local.vpc_cidr


### PR DESCRIPTION
Updated terraform-aws-module-vpc to >4.0

*Issue #, if available:*

*Description of changes:*
Updated the version of the terraform-aws-module-vpc to get past errors when running the lab

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
