### PR TITLE
Links and text updates - Running efficient Kubernetes Clusters on Amazon EC2 with Karpenter Workshop

### DIFF
--- a/content/karpenter/040_k8s_tools/explore_kube_ops_view.md
+++ b/content/karpenter/040_k8s_tools/explore_kube_ops_view.md
@@ -4,7 +4,7 @@ date: 2018-08-07T08:30:11-07:00
 weight: 30
 ---
 
-We installed [Kube-ops-view](https://github.com/hjacobs/kube-ops-view) from **[Henning Jacobs](https://github.com/hjacobs)**. Kube-ops-view will help with understanding our cluster setup in a visual way, similar to `eks-node-viewer`.
+We installed [Kube-ops-view](https://codeberg.org/hjacobs/kube-ops-view) from **[Henning Jacobs](https://codeberg.org/hjacobs)**. Kube-ops-view will help with understanding our cluster setup in a visual way, similar to `eks-node-viewer`.
 
 {{% notice warning %}}
 Monitoring and visualization shouldn't be typically be exposed publicly unless the service is properly secured and provide methods for authentication and authorization. You can still deploy kube-ops-view as Service of type **ClusterIP** by removing the  `--set service.type=LoadBalancer` section and using `kubectl proxy`. Kube-ops-view does also [support Oauth 2](https://github.com/hjacobs/kube-ops-view#configuration) 

--- a/content/karpenter/050_karpenter/advanced_provisioner.md
+++ b/content/karpenter/050_karpenter/advanced_provisioner.md
@@ -16,7 +16,7 @@ In the previous sections, we did set up a default Provisioner and did scale a si
 To start the exercises, let's set up our Provisioner CRD (Custom Resource Definition). We will set up one for the `default`, overriding the previous one we created, and a new Provisioner named `team1`.
 
 {{% notice tip%}}
-Spend some time familiarizing yourself with the configuration. You can read more about Provisioner CRD configuration for the AWS Cloud Provider **[here](https://karpenter.sh/docs/aws/)**
+Spend some time familiarizing yourself with the configuration. You can read more about Provisioner CRD configuration for the AWS Cloud Provider **[here](https://karpenter.sh/docs/concepts/provisioners/)**
 {{% /notice %}}
 
 Run the following command to change the configuration of the `default` Provisioner.

--- a/content/karpenter/050_karpenter/automatic_node_provisioning.md
+++ b/content/karpenter/050_karpenter/automatic_node_provisioning.md
@@ -120,7 +120,7 @@ Instances types might be different depending on the region selected.
 
 All this instances are the suitable instances that reduce the waste of resources (memory and CPU) for the pod submitted. If you are interested in Algorithms, internally Karpenter is using a [First Fit Decreasing (FFD)](https://en.wikipedia.org/wiki/Bin_packing_problem#First_Fit_Decreasing_(FFD)) approach. Note however this can change in the future.
 
-We did set Karpenter Provisioner to use [EC2 Spot instances](https://aws.amazon.com/ec2/spot/), and there was no `instance-types` [requirement section in the Provisioner to filter the type of instances](https://karpenter.sh/v0.19.2/provisioner/#instance-types). This means that Karpenter will use the default value of instances types to use. The default value includes all instance types with the exclusion of metal (non-virtualized), [non-HVM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html), and GPU instances.Internally Karpenter used **EC2 Fleet in Instant mode** to provision the instances. You can read more about EC2 Fleet Instant mode [**here**](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instant-fleet.html). Here are a few properties to mention about EC2 Fleet instant mode that are key for Karpenter. 
+We did set Karpenter Provisioner to use [EC2 Spot instances](https://aws.amazon.com/ec2/spot/), and there was no `instance-types` [requirement section in the Provisioner to filter the type of instances](https://karpenter.sh/docs/concepts/instance-types/). This means that Karpenter will use the default value of instances types to use. The default value includes all instance types with the exclusion of metal (non-virtualized), [non-HVM](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/virtualization_types.html), and GPU instances. Internally Karpenter used **EC2 Fleet in Instant mode** to provision the instances. You can read more about EC2 Fleet Instant mode [**here**](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instant-fleet.html). Here are a few properties to mention about EC2 Fleet instant mode that are key for Karpenter. 
 
 * EC2 Fleet instant mode provides a synchronous call to procure instances, including EC2 Spot, this simplifies and avoid error when provisioning instances. For those of you familiar with [Cluster Autoscaler on AWS](https://github.com/kubernetes/autoscaler/blob/c4b56ea56136681e8a8ff654dfcd813c0d459442/cluster-autoscaler/cloudprovider/aws/auto_scaling_groups.go#L33-L36), you may know about how it uses `i-placeholder` to coordinate instances that have been created in asynchronous ways.
 
@@ -170,18 +170,18 @@ System Info:
   OS Image:                   Amazon Linux 2
   Operating System:           linux
   Architecture:               amd64
-  Container Runtime Version:  containerd://1.6.6
-  Kubelet Version:            v1.23.9-eks-ba74326
+  Container Runtime Version:  containerd://1.6.19
+  Kubelet Version:            v1.28.1-eks-43840fb
   ...
 ```
 
-* The instance selected has been created with the default architecture Karpenter will use when the Provisioner CRD requirement for `kubernetes.io/arch` [Architecture](https://karpenter.sh/v0.19.2/provisioner/#architecture) has not been provided.
+* The instance selected has been created with the default architecture Karpenter will use when the Provisioner CRD requirement for `kubernetes.io/arch` [Architecture](https://karpenter.sh/docs/concepts/provisioners/#architecture) has not been provided.
 
 * The Container Runtime used for Karpenter nodes is containerd. You can read more about containerd [**here**](https://containerd.io/)  
 
 
 {{% notice info%}}
-At this time, Karpenter only supports Linux OS nodes.
+Karpenter supports Linux and Windows [(Starting with v0.29.0)](https://karpenter.sh/v0.29/getting-started/getting-started-with-karpenter/) OS nodes.
 {{% /notice %}}
 
 {{% /expand %}}
@@ -276,7 +276,7 @@ In this section we have learned:
 
 * Karpenter can scale-out from zero when applications have available working pods and scale-in to zero when there are no running jobs or pods.
 
-* Provisioners can be setup to define governance and rules that define how nodes will be provisioned within a cluster partition. We can setup requirements such as `karpenter.sh/capacity-type` to allow on-demand and spot instances or use `karpenter.k8s.aws/instance-size` to filter smaller sizes. The full list of supported labels is available **[here](https://karpenter.sh/v0.19.2/tasks/scheduling/#selecting-nodes)**
+* Provisioners can be setup to define governance and rules that define how nodes will be provisioned within a cluster partition. We can setup requirements such as `karpenter.sh/capacity-type` to allow on-demand and spot instances or use `karpenter.k8s.aws/instance-size` to filter smaller sizes. The full list of supported labels is available **[here](https://karpenter.sh/docs/concepts/scheduling/#labels)**
 
 * Karpenter uses cordon and drain [best practices](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/) to terminate nodes. The configuration of when a node is terminated can be controlled with `ttlSecondsAfterEmpty`
 

--- a/content/karpenter/050_karpenter/consolidation.md
+++ b/content/karpenter/050_karpenter/consolidation.md
@@ -222,7 +222,7 @@ Karpenter logs should show a sequence of events similar to the one below.
 #### 4) Scale the `inflate` service to 3 replicas, what should happen ?
 {{%expand "Click here to show the answer" %}} 
 
-Run the following command to set the number of replicas to 6
+Run the following command to set the number of replicas to 3.
 
 ```
 kubectl scale deployment inflate --replicas 3

--- a/content/karpenter/050_karpenter/explore_karpenter.md
+++ b/content/karpenter/050_karpenter/explore_karpenter.md
@@ -5,7 +5,7 @@ weight: 20
 draft: false
 ---
 
-In this section, we will review Karpenter which we have pre-installed and learn how to configure a default [Provisioner CRD](https://karpenter.sh/docs/provisioner-crd/) to set the configuration. Karpenter can installed in clusters with a [helm](https://helm.sh/) chart, we used Amazon EKS blueprints. Karpenter follows best practices for kubernetes controllers for its configuration. Karpenter uses [Custom Resource Definition(CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) to declare its configuration. Custom Resources are extensions of the Kubernetes API. One of the premises of Kubernetes is the [declarative aspect of its APIs](https://kubernetes.io/docs/concepts/overview/kubernetes-api/). Karpenter simplifies its configuration by adhering to that principle.
+In this section, we will review Karpenter which we have pre-installed and learn how to configure a default [Provisioner CRD](https://karpenter.sh/docs/concepts/provisioners/) to set the configuration. Karpenter can installed in clusters with a [helm](https://helm.sh/) chart, we used Amazon EKS blueprints. Karpenter follows best practices for kubernetes controllers for its configuration. Karpenter uses [Custom Resource Definition(CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) to declare its configuration. Custom Resources are extensions of the Kubernetes API. One of the premises of Kubernetes is the [declarative aspect of its APIs](https://kubernetes.io/docs/concepts/overview/kubernetes-api/). Karpenter simplifies its configuration by adhering to that principle.
 
 ## Explore the Karpenter installation
 

--- a/content/karpenter/050_karpenter/multiple_architectures.md
+++ b/content/karpenter/050_karpenter/multiple_architectures.md
@@ -113,7 +113,7 @@ To scale up the deployment run the command:
 kubectl scale deployment inflate-amd64 --replicas 2
 ```
 
-Before we check the selected node, let's cover what Karpenter is expected to do in this scenario. Node selectors are an opt-in mechanism which allow users to specify the nodes on which a pod can scheduled. Karpenter recognizes well-known node selectors on unschedulable pods and uses them to constrain the nodes it provisions. `kubernetes.io/arch` is one of the [well-known node selectors](https://kubernetes.io/docs/reference/labels-annotations-taints/)  supported by Karpenter. When Karpenter finds that the `kubernetes.io/arch` was set to `amd64` it does ensure ensure that provisioned nodes are constrained accordingly to `amd64` instances.
+Before we check the selected node, let's cover what Karpenter is expected to do in this scenario. Node selectors are an opt-in mechanism which allow users to specify the nodes on which a pod can scheduled. Karpenter recognizes well-known node selectors on unschedulable pods and uses them to constrain the nodes it provisions. `kubernetes.io/arch` is one of the [well-known node selectors](https://kubernetes.io/docs/reference/labels-annotations-taints/)  supported by Karpenter. When Karpenter finds that the `kubernetes.io/arch` was set to `amd64` it does ensure that provisioned nodes are constrained accordingly to `amd64` instances.
 
 Let's confirm that was the case and only `amd64` considered for scaling up. We can check karpenter logs by running the following command.
 

--- a/content/karpenter/050_karpenter/set_up_the_provisioner.md
+++ b/content/karpenter/050_karpenter/set_up_the_provisioner.md
@@ -65,7 +65,7 @@ We are asking the provisioner to start all new nodes with a label `intent: apps`
 
 The configuration for the provider is split into two parts. The first one defines the provisioner relevant spec. The second part is defined by the provider implementation, in our case `AWSNodeTemplate` and defines the specific configuration that applies to that cloud provider. The Provisioner configuration is quite simple. During the workshop we will change the Provisioner and even use multiple provisioners. For the moment let's focus in a few of the settings used.
 
-* **Requirements Section**: The [Provisioner CRD](https://karpenter.sh/docs/provisioner-crd/) supports defining node properties like instance type and zone. For example, in response to a label of topology.kubernetes.io/zone=us-east-1c, Karpenter will provision nodes in that availability zone. In this example we are setting the `karpenter.sh/capacity-type` to procure EC2 Spot instances, and  `karpenter.k8s.aws/instance-size` to avoid smaller instances. You can learn which other properties are [available here](https://karpenter.sh/v0.19.2/tasks/scheduling/#selecting-nodes). We will work on a few more during the workshop.
+* **Requirements Section**: The [Provisioner CRD](https://karpenter.sh/docs/concepts/provisioners/) supports defining node properties like instance type and zone. For example, in response to a label of topology.kubernetes.io/zone=us-east-1c, Karpenter will provision nodes in that availability zone. In this example we are setting the `karpenter.sh/capacity-type` to procure EC2 Spot instances, and  `karpenter.k8s.aws/instance-size` to avoid smaller instances. You can learn which other properties are [available here](https://karpenter.sh/docs/concepts/scheduling/#selecting-nodes). We will work on a few more during the workshop.
 * **Limits section**: Provisioners can define a limit in the number of CPU's and memory allocated to that particular provisioner and part of the cluster.
 * **Provider section**: This provisioner uses `securityGroupSelector` and `subnetSelector` to discover resources used to launch nodes. It uses the tags that Karpenter attached to the subnets.
 * **ttlSecondsAfterEmpty**: value configures Karpenter to terminate empty nodes. This behavior can be disabled by leaving the value undefined. In this case we have set it for a quick demonstration to a value of 30 seconds.
@@ -75,7 +75,7 @@ The configuration for the provider is split into two parts. The first one define
 
 
 {{% notice info %}}
-Karpenter has been designed to be generic and support other Cloud and Infrastructure providers. At the moment of writing this workshop, **Karpenter v0.19.2** is the main implementation and only available on AWS. You can read more about the **[configuration available for the AWS Provisioner here](https://karpenter.sh/docs/concepts/provisioners/)**. 
+Karpenter has been designed to be generic and support other Cloud and Infrastructure providers. At the moment of writing this workshop, **Karpenter v0.29.2** is the main implementation and only available on AWS. You can read more about the **[configuration available for the AWS Provisioner here](https://karpenter.sh/docs/concepts/provisioners/)**. 
 {{% /notice %}}
 
 ## Displaying Karpenter Logs

--- a/content/karpenter/060_scaling/build_and_push_to_ecr.md
+++ b/content/karpenter/060_scaling/build_and_push_to_ecr.md
@@ -35,7 +35,7 @@ The steps above:
 
 
 * Create a new registry in ECR for the monte-carlo-sim application
-* Build the application using the Dockerfile. The Dockerfile uses a [multi-stage](https:/docs.docker.com/develop/develop-images/multistage-build/) build that
+* Build the application using the Dockerfile. The Dockerfile uses a [multi-stage](https://docs.docker.com/build/building/multi-stage/) build that
 compiles the Go application and then packages it in a minimal image that pulls from [scratch](https://hub.docker.com/_/scratch/). The size of this Docker image is ~ 3.2 MiB.
 * The newly created image is pushed into the registry and the registry is stored as an environment variable so we can refer to it in the rest of the workshop.
 


### PR DESCRIPTION
*Description of changes:*

Running efficient Kubernetes Clusters on Amazon EC2 with Karpenter Workshop

Changes:



1/  Status: Done ✅ 

Type: Link error
Where: Explore Karpenter installation
Link: https://catalog.us-east-1.prod.workshops.aws/workshops/f6b4587e-b8a5-4a43-be87-26bd85a70aba/en-US/050-karpenter/explore-karpenter-installation

In this section, we will review Karpenter which we have pre-installed and learn how to configure a default [Provisioner CRD ](https://karpenter.sh/docs/provisioner-crd/)to set the configuration.

The link Provisioner CRD is broken, need to be change from https://karpenter.sh/docs/provisioner-crd/ to https://karpenter.sh/docs/concepts/provisioners/



2/  Status:  Done ✅

Type: Grammar error
Where: Karpenter → Multi-Architecture deployments → 1) How would you Scale the inflate-amd64 deployment to 2 replicas ? What nodes were selected by Karpenter ?
Link: https://catalog.us-east-1.prod.workshops.aws/workshops/f6b4587e-b8a5-4a43-be87-26bd85a70aba/en-US/050-karpenter/multiple-architectures
When Karpenter finds that the kubernetes.io/arch was set to amd64 it does ensure ensure that provisioned nodes are constrained accordingly to amd64 instances.


3/ Status: Done ✅

Type: Link change
Where:  Explore Cluster visualization Tools → Kube-ops-view
Link: https://catalog.us-east-1.prod.workshops.aws/workshops/f6b4587e-b8a5-4a43-be87-26bd85a70aba/en-US/040-k8s-tools

May we need to change the archive link Kube-ops-view from github to the new one? https://codeberg.org/hjacobs/kube-ops-view



4/ Status: Done ✅ 

Type: Links error
Where: Karpenter → Set up the Provisioner → Requirements Section: 
Link: https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/050-karpenter/set-up-the-provisioner

The link Provisioner CRD is broken, need to be change from https://karpenter.sh/docs/provisioner-crd/ to https://karpenter.sh/docs/concepts/provisioners/

The link available here is broken, need to be change from https://karpenter.sh/v0.19.2/tasks/scheduling/#selecting-nodes to https://karpenter.sh/v0.29/concepts/scheduling/#selecting-nodes



5/ Status:  Done ✅

Type: Version
Where: Karpenter → Set up the Provisioner → Important Section: 
Link: https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/050-karpenter/set-up-the-provisioner
Karpenter version running on the workshop is v0.29.2.





6/ Status: Done ✅

Type: Link and text error.
Where: Karpenter →Automatic provisioner → 3) Which-instance-type-did-karpenter-use-when-increasing-the-instances-why-that-instance? 
Link: https://catalog.us-east-1.prod.workshops.aws/workshops/f6b4587e-b8a5-4a43-be87-26bd85a70aba/en-US/050-karpenter/automatic-node-provisioning#3)-which-instance-type-did-karpenter-use-when-increasing-the-instances-why-that-instance


The link requirement section in the Provisioner to filter the type of instances  is broken, need to be change from https://karpenter.sh/v0.19.2/provisioner/#instance-types to https://karpenter.sh/docs/concepts/instance-types/

instances.Internally Karpenter



7/ Status: Done ✅

Type: Link error and text to be updated.
Where: Karpenter →Automatic provisioner → 4) what-are-the-new-instance-properties-and-labels?
Link: https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/050-karpenter/automatic-node-provisioning#4)-what-are-the-new-instance-properties-and-labels


7.1 - System Info:
...
OS Image: Amazon Linux 2
Operating System: linux
Architecture: amd64
Container Runtime Version: containerd://1.6.19
Kubelet Version: v1.28.1-eks-43840fb
...

7.2 - The link Architecture is broken, need to be change from https://karpenter.sh/v0.19.2/provisioner/#architecture to https://karpenter.sh/docs/concepts/provisioners/#architecture

7.3 - Warning Important:
Karpenter supports Windows OS nodes.
https://karpenter.sh/docs/concepts/provisioners/#operating-system
https://aws.amazon.com/about-aws/whats-new/2023/07/karpenter-windows-containers/



8/  Status: Done ✅

Type: Link error.
Where: Karpenter → Automatic provisioner → What Have we learned in this section:
Link: https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/050-karpenter/automatic-node-provisioning#what-have-we-learned-in-this-section


The full list of supported labels is available here.

The link here is broken, need to be change from https://karpenter.sh/v0.19.2/tasks/scheduling/#selecting-nodes to https://karpenter.sh/docs/concepts/scheduling/#labels



9/ Status: Done ✅

Type: Text error.
Where: Karpenter → Consolidation → 4) Scale the inflate service to 3 replicas, what should happen ?
Link: https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/050-karpenter/consolidation#4)-scale-the-inflate-service-to-3-replicas-what-should-happen

Run the following command to set the number of replicas to 6.  

Change to 3.



10/ Status: Done ✅

Type:  Link error.
Where: Karpenter → Deploying Multiple Provisioners → Setting up the Provisioners CRD
Link: https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/050-karpenter/advanced-provisioner#setting-up-the-provisioners-crd

The link here is broken, need to be change from https://karpenter.sh/docs/aws/ to https://karpenter.sh/docs/concepts/provisioners/



11/ Status: Done ✅

Type:  Link error.
Where: Scaling an application and cluster → Build the Microservice
Link: https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/060-scaling/build-and-push-to-ecr

The link multi-stage is broken, need to be change from https://catalog.us-east-1.prod.workshops.aws/event/dashboard/en-US/workshop/060-scaling/build-and-push-to-ecr/https:/docs.docker.com/develop/develop-images/multistage-build/ to https://docs.docker.com/build/building/multi-stage/