### PR TITLE
Deleting autoScalingServiceLinkedRole in efficient-auto-scaling-quick…

### DIFF
--- a/content/efficient-and-resilient-ec2-auto-scaling/files/efficient-auto-scaling-quickstart-cnf.yml
+++ b/content/efficient-and-resilient-ec2-auto-scaling/files/efficient-auto-scaling-quickstart-cnf.yml
@@ -129,12 +129,6 @@ Resources:
           RouteTableId: !Ref RouteTable
           SubnetId: !Ref PublicSubnet2
 
-  autoScalingServiceLinkedRole:
-    Properties:
-      AWSServiceName: autoscaling.amazonaws.com
-      Description: Default Service-Linked Role enables access to AWS Services and Resources
-        used or managed by Auto Scaling
-    Type: AWS::IAM::ServiceLinkedRole
 ################## Launch Template #################
   MyLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate


### PR DESCRIPTION
…start-cnf.yml

*Issue #, if available:*
None
*Description of changes:*
Removed autoScalingServiceLinkedRole in the efficient-and-resilient-ec2-auto-scaling workshop to support EE to WS migration 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
