### PR TITLE
Fix duplicate key errors in CF templates

### DIFF
--- a/content/efficient-and-resilient-ec2-auto-scaling/files/efficient-auto-scaling-quickstart-cnf.yml
+++ b/content/efficient-and-resilient-ec2-auto-scaling/files/efficient-auto-scaling-quickstart-cnf.yml
@@ -399,7 +399,7 @@ Resources:
       Tags:
         - Key: Environment
           Value: AWS Example
-      Content: Yaml
+      DocumentFormat: Yaml
       DocumentType: Command
       Content:
         schemaVersion: '2.2'

--- a/content/karpenter/010_prerequisites/prerequisites.files/eks-spot-workshop-quickstart-cnf.yml
+++ b/content/karpenter/010_prerequisites/prerequisites.files/eks-spot-workshop-quickstart-cnf.yml
@@ -254,7 +254,7 @@ Resources:
       Tags:
         - Key: Environment
           Value: AWS Example
-      Content: Yaml
+      DocumentFormat: Yaml
       DocumentType: Command
       Content:
         schemaVersion: '2.2'

--- a/content/using_ec2_spot_instances_with_eks/010_prerequisites/prerequisites.files/eks-spot-workshop-quickstart-cnf.yml
+++ b/content/using_ec2_spot_instances_with_eks/010_prerequisites/prerequisites.files/eks-spot-workshop-quickstart-cnf.yml
@@ -229,7 +229,7 @@ Resources:
       Tags:
         - Key: Environment
           Value: AWS Example
-      Content: Yaml
+      DocumentFormat: Yaml
       DocumentType: Command
       Content:
         schemaVersion: '2.2'

--- a/workshops/amazon-ec2-spot-cicd-workshop/gitlab-spot/gitlab-deploy.yml
+++ b/workshops/amazon-ec2-spot-cicd-workshop/gitlab-spot/gitlab-deploy.yml
@@ -587,7 +587,7 @@ Resources:
   GitLabWorkshopC9SSMDocument: 
     Type: AWS::SSM::Document
     Properties:
-      Content: Yaml
+      DocumentFormat: Yaml
       DocumentType: Command
       Content: 
         schemaVersion: '2.2'

--- a/workshops/running_spark_apps_with_emr_on_spot_instances/emr-spark-spot-workshop-quickstarter-cnf.yaml
+++ b/workshops/running_spark_apps_with_emr_on_spot_instances/emr-spark-spot-workshop-quickstarter-cnf.yaml
@@ -257,7 +257,7 @@ Resources:
       Tags:
         - Key: Environment
           Value: AWS Example
-      Content: Yaml
+      DocumentFormat: Yaml
       DocumentType: Command
       Content:
         schemaVersion: '2.2'


### PR DESCRIPTION
*Issue #, if available:*

CloudFormation stack templates where having a duplicate key named `Content`, where the key (most probably) should have been `DocumentType`.

*Description of changes:*

Changing the key used to declare the `Yaml` type from `Content` to `DocumentType`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
