### PR TITLE
Update review-outputs.md : Added STACK_NAME

### DIFF
--- a/content/monte-carlo-with-batch/start/review-outputs.md
+++ b/content/monte-carlo-with-batch/start/review-outputs.md
@@ -34,6 +34,9 @@ You will create other AWS resources using the AWS CLI in [Cloud9](https://aws.am
 Navigate to the [Cloud9 console](https://console.aws.amazon.com/cloud9) and open the environment that was created for you. Execute the following commands to retrieve the outputs of the CloudFormation stack:
 
 ```
+export AWS_DEFAULT_REGION=$(curl -s  169.254.169.254/latest/dynamic/instance-identity/document | jq -r '.region')
+export STACK_NAME="MonteCarloWithBatch"
+
 for output in $(aws cloudformation describe-stacks --stack-name ${STACK_NAME} --query 'Stacks[].Outputs[].OutputKey' --output text)
 do
     export $output=$(aws cloudformation describe-stacks --stack-name ${STACK_NAME} --query 'Stacks[].Outputs[?OutputKey==`'$output'`].OutputValue' --output text)


### PR DESCRIPTION
Under: Gathering the CloudFormation outputs

The "STACK_NAME" value wasn't exported hence the describe-stack command wouldn't work unless you declare STACK_NAME manually

*Issue #, if available:*

*Description of changes:* added export command to export the STACK-NAME and export the default region fetching from cloud9 EC2 instance userData


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
