### PR TITLE
Update Dockerfile: replaced libgl1-mesa-glx package with libgl1

### DIFF
--- a/content/rendering-with-batch/rendering-with-batch.files/docker-files/Dockerfile
+++ b/content/rendering-with-batch/rendering-with-batch.files/docker-files/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     libxxf86vm-dev \
     libfontconfig1 \
     libxrender1 \
-    libgl1-mesa-glx
+    libgl1
 
 # Download and install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
Got error "libgl1-mesa-glx package not found" even after adding universe repository add-apt-repository.

*Issue #, if available:*

*Description of changes:* Replaced libgl1-mesa-glx package with libgl1 package to provide the necessary OpenGL libraries for Blender to function


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
