### PR TITLE
fix(security): Remove YouTube iframe embeds to resolve sandbox attrib

### DIFF
--- a/content/ecs-spot-capacity-providers/conclusion.md
+++ b/content/ecs-spot-capacity-providers/conclusion.md
@@ -30,4 +30,4 @@ There is one more thing that we've accomplished!
 We have achieved a significant cost saving over On-Demand prices that we can apply in a controlled way and at scale. We hope this savings will help you try new experiments or build other cool projects. **Now Go Build** !
 {{% /notice %}}
 
-{{< youtube 3wGeqmSwz9k >}}
+[Watch: Workshop Conclusion Video](https://www.youtube.com/watch?v=3wGeqmSwz9k)

--- a/content/karpenter/300_conclusion/conclusion.md
+++ b/content/karpenter/300_conclusion/conclusion.md
@@ -37,4 +37,4 @@ There is one more thing that we've accomplished by using EC2 Spot instances in t
 We have achieved a significant cost saving over On-Demand prices that we can apply in a controlled way and at scale. We hope this helps you use Karpenter to simpify your deployments and use EC2 Spot Instances for your stateless, flexible workloads. We hope this savings will help you try new experiments or build other cool projects. **Now Go Build** !
 {{% /notice %}}
 
-{{< youtube 3wGeqmSwz9k >}}
+[Watch: Workshop Conclusion Video](https://www.youtube.com/watch?v=3wGeqmSwz9k)

--- a/content/karpenter/test.md
+++ b/content/karpenter/test.md
@@ -15,7 +15,7 @@ The CloudFormation stack created the EKS cluster using [**Terraform**](https://w
 
 **Terraform** is an infrastructure as code tool that lets you build, change, and version infrastructure safely and efficiently in AWS. **EKS Blueprints for Terraform** helps you compose complete EKS clusters that are fully bootstrapped with the operational software that is needed to deploy and operate workloads. With EKS Blueprints, you describe the configuration for the desired state of your EKS environment, such as the control plane, worker nodes, and Kubernetes add-ons, as an IaC blueprint. Once a blueprint is configured, you can use it to stamp out consistent environments across multiple AWS accounts and Regions using continuous deployment automation.
 
-{{< youtube DhoZMbqwwsw >}}
+[Watch: EKS Blueprints for Terraform Overview](https://www.youtube.com/watch?v=DhoZMbqwwsw)
 
 #### Update the kube-config file:
 Before you can start running all the commands included in this workshop, you need to update the kube-config file with the proper credentials to access the cluster. To do so, in your Cloud9 workspace run the following command:

--- a/content/running_spark_apps_with_emr_on_spot_instances/calltoaction.md
+++ b/content/running_spark_apps_with_emr_on_spot_instances/calltoaction.md
@@ -22,6 +22,4 @@ Visit the [**Amazon EMR on EC2 Spot Instances**](https://aws.amazon.com/ec2/spot
 
 Read the blog post: [**Best practices for running Apache Spark applications using Amazon EC2 Spot Instances with Amazon EMR**](https://aws.amazon.com/blogs/big-data/best-practices-for-running-apache-spark-applications-using-amazon-ec2-spot-instances-with-amazon-emr/)  
 
-Watch the AWS Online Tech-Talk: 
-
-{{< youtube u5dFozl1fW8 >}}
+Watch the AWS Online Tech-Talk: [Best Practices for Running Spark Applications Using Spot Instances on EMR](https://www.youtube.com/watch?v=u5dFozl1fW8)

--- a/content/using_ec2_spot_instances_with_eks/021_terraform/_index.md
+++ b/content/using_ec2_spot_instances_with_eks/021_terraform/_index.md
@@ -15,7 +15,7 @@ The CloudFormation stack created the EKS cluster using [**Terraform**](https://w
 
 **Terraform** is an infrastructure as code tool that lets you build, change, and version infrastructure safely and efficiently in AWS. **EKS Blueprints for Terraform** helps you compose complete EKS clusters that are fully bootstrapped with the operational software that is needed to deploy and operate workloads. With EKS Blueprints, you describe the configuration for the desired state of your EKS environment, such as the control plane, worker nodes, and Kubernetes add-ons, as an IaC blueprint. Once a blueprint is configured, you can use it to stamp out consistent environments across multiple AWS accounts and Regions using continuous deployment automation.
 
-{{< youtube DhoZMbqwwsw >}}
+[Watch: EKS Blueprints for Terraform Overview](https://www.youtube.com/watch?v=DhoZMbqwwsw)
 
 #### Update the kube-config file:
 Before you can start running all the commands included in this workshop, you need to update the kube-config file with the proper credentials to access the cluster. To do so, in your Cloud9 workspace run the following command:

--- a/content/using_ec2_spot_instances_with_eks/300_conclusion/conclusion.md
+++ b/content/using_ec2_spot_instances_with_eks/300_conclusion/conclusion.md
@@ -37,4 +37,4 @@ There is one more thing that we've accomplished!
 We have achieved a significant cost saving over On-Demand prices that we can apply in a controlled way and at scale. We hope this savings will help you try new experiments or build other cool projects. **Now Go Build** !
 {{% /notice %}}
 
-{{< youtube 3wGeqmSwz9k >}}
+[Watch: Workshop Conclusion Video](https://www.youtube.com/watch?v=3wGeqmSwz9k)


### PR DESCRIPTION
Replace all YouTube iframe embeds with direct links to resolve insecure iframe security findings.

Affected pages:
- EMR Spark workshop calltoaction
- EKS workshop terraform intro and conclusion
- ECS workshop conclusion
- Karpenter workshop test page and conclusion

sim: V1766180218

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
