### PR TITLE
fix(security): Add Content-Security-Policy headers to resolve XSS vulnerability

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -14,3 +14,14 @@ frontend:
       - '**/*'
   cache:
     paths: []
+customHeaders:
+  - pattern: '**/*'
+    headers:
+      - key: Content-Security-Policy
+        value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'"
+      - key: X-Frame-Options
+        value: SAMEORIGIN
+      - key: X-Content-Type-Options
+        value: nosniff
+      - key: Referrer-Policy
+        value: strict-origin-when-cross-origin


### PR DESCRIPTION
Add CSP headers via Amplify customHeaders configuration to prevent potential XSS attacks. Also includes additional security headers:
- X-Frame-Options
- X-Content-Type-Options
- Referrer-Policy

sim: V2068970797
sim: V1886431534

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
